### PR TITLE
ビルドコマンドをリテラルスタイルに修正

### DIFF
--- a/codebuild/buildspec_apply.yml
+++ b/codebuild/buildspec_apply.yml
@@ -23,5 +23,6 @@ phases:
       - terraform -chdir="${TFDIR}" init -no-color
   build:
     commands:
-      - APPLY=$(terraform -chdir="${TFDIR}" apply -auto-approve -no-color 2>&1)
-      - echo "${APPLY}" | tfnotify --config "${TFNCONF}" apply --title "${TITLE}" --message "${MSG}"
+      - |
+        APPLY=$(terraform -chdir="${TFDIR}" apply -auto-approve -no-color 2>&1)
+        echo "${APPLY}" | tfnotify --config "${TFNCONF}" apply --title "${TITLE}" --message "${MSG}"

--- a/codebuild/buildspec_plan.yml
+++ b/codebuild/buildspec_plan.yml
@@ -23,5 +23,6 @@ phases:
       - terraform -chdir="${TFDIR}" init -no-color
   build:
     commands:
-      - PLAN=$(terraform -chdir="${TFDIR}" plan -no-color 2>&1)
-      - echo "${PLAN}" | tfnotify --config "${TFNCONF}" plan --title "${TITLE}" --message "${MSG}"
+      - |
+        PLAN=$(terraform -chdir="${TFDIR}" plan -no-color 2>&1)
+        echo "${PLAN}" | tfnotify --config "${TFNCONF}" plan --title "${TITLE}" --message "${MSG}"


### PR DESCRIPTION
# 概要

ビルドコマンドをリテラルスタイルに修正

## 変更理由

`terraform plan / apply` がエラーとなる場合、CI のログや GitHub の PR にエラー内容が表示されずトラブルシュートが難しいため修正する

## 変更内容

`buildspec.yml` のビルドコマンド部分をリテラルスタイルに修正